### PR TITLE
fix(video-assignment): clear pending resolves and fix bogus error log

### DIFF
--- a/web/internal/channel_handlers/media_stats_channel_handler.ts
+++ b/web/internal/channel_handlers/media_stats_channel_handler.ts
@@ -109,7 +109,7 @@ export class MediaStatsChannelHandler {
       response,
     );
     const resolve = this.pendingRequestResolveMap.get(response.requestId);
-    if (resolve) {
+    if(resolve) {
       resolve(response.status);
       this.pendingRequestResolveMap.delete(response.requestId);
     }

--- a/web/internal/channel_handlers/media_stats_channel_handler.ts
+++ b/web/internal/channel_handlers/media_stats_channel_handler.ts
@@ -109,7 +109,7 @@ export class MediaStatsChannelHandler {
       response,
     );
     const resolve = this.pendingRequestResolveMap.get(response.requestId);
-    if(resolve) {
+    if (resolve) {
       resolve(response.status);
       this.pendingRequestResolveMap.delete(response.requestId);
     }

--- a/web/internal/channel_handlers/video_assignment_channel_handler.ts
+++ b/web/internal/channel_handlers/video_assignment_channel_handler.ts
@@ -122,10 +122,9 @@ export class VideoAssignmentChannelHandler {
     );
     const resolve = this.pendingRequestResolveMap.get(response.requestId);
     if (resolve){
-      try{
+      try {
         resolve(response.status);
-      }
-      finally{
+      } finally {
         this.pendingRequestResolveMap.delete(response.requestId);
       }
     }

--- a/web/internal/channel_handlers/video_assignment_channel_handler.ts
+++ b/web/internal/channel_handlers/video_assignment_channel_handler.ts
@@ -120,7 +120,15 @@ export class VideoAssignmentChannelHandler {
       'Video assignment channel: recieved response',
       response,
     );
-    this.pendingRequestResolveMap.get(response.requestId)?.(response.status);
+    const resolve = this.pendingRequestResolveMap.get(response.requestId);
+    if (resolve){
+      try{
+        resolve(response.status);
+      }
+      finally{
+        this.pendingRequestResolveMap.delete(response.requestId);
+      }
+    }
   }
 
   private onVideoAssignmentResources(resources: VideoAssignmentResource[]) {
@@ -227,10 +235,12 @@ export class VideoAssignmentChannelHandler {
           }
         }
         // tslint:enable:no-unnecessary-type-assertion
-        this.channelLogger?.log(
-          LogLevel.ERRORS,
-          'Video assignment channel: server sent a canvas that was not created by the client',
-        );
+        else {
+          this.channelLogger?.log(
+            LogLevel.ERRORS,
+            'Video assignment channel: server sent a canvas that was not created by the client',
+          );
+        }
       },
     );
   }


### PR DESCRIPTION
### **What changed**

Fixed an error log in video_assignment_channel_handler that was being emitted unconditionally. It now logs only when the server sends a canvas ID that the client never created (missing layout).

Prevented a memory/state leak by always clearing pendingRequestResolveMap entries when onVideoAssignmentResponse is received (using try/finally to guarantee cleanup even if the callback throws).

### **Why**

The bogus error log polluted logs and made real issues harder to spot.

Pending request resolvers were never removed, causing unbounded growth during long sessions or retries.

### **Files**

`web/internal/channel_handlers/video_assignment_channel_handler.ts`