### PR TITLE
Fix: Fix Multi-Video Stream Playback and Internal Frame Stealing

### DIFF
--- a/web/internal/channel_handlers/media_entries_channel_handler.ts
+++ b/web/internal/channel_handlers/media_entries_channel_handler.ts
@@ -382,20 +382,24 @@ export class MediaEntriesChannelHandler {
       internalMeetStreamTrack,
     ] of this.internalMeetStreamTrackMap.entries()) {
       // Only audio tracks are assigned here.
-      if (meetStreamTrack.mediaStreamTrack.kind !== 'audio') continue;
-      const receiver = internalMeetStreamTrack.receiver;
-      const contributingSources: RTCRtpContributingSource[] =
-        receiver.getContributingSources();
-      for (const contributingSource of contributingSources) {
-        if (contributingSource.source === internalMediaEntry.audioCsrc) {
-          internalMediaEntry.audioMeetStreamTrack.set(meetStreamTrack);
-          internalMeetStreamTrack.mediaEntry.set(mediaEntry);
-          return;
+      if (
+        meetStreamTrack.mediaStreamTrack.kind === 'audio' &&
+        !meetStreamTrack.mediaEntry.get()
+      ) {
+        const receiver = internalMeetStreamTrack.receiver;
+        const contributingSources: RTCRtpContributingSource[] =
+          receiver.getContributingSources();
+        for (const contributingSource of contributingSources) {
+          if (contributingSource.source === internalMediaEntry.audioCsrc) {
+            internalMediaEntry.audioMeetStreamTrack.set(meetStreamTrack);
+            internalMeetStreamTrack.mediaEntry.set(mediaEntry);
+            return;
+          }
         }
+        // If Audio Csrc is not found in contributing sources, fall back to
+        // polling frames for assignment.
+        internalMeetStreamTrack.maybeAssignMediaEntryOnFrame(mediaEntry, 'audio');
       }
-      // If Audio Csrc is not found in contributing sources, fall back to
-      // polling frames for assignment.
-      internalMeetStreamTrack.maybeAssignMediaEntryOnFrame(mediaEntry, 'audio');
     }
   }
 }

--- a/web/internal/channel_handlers/video_assignment_channel_handler.ts
+++ b/web/internal/channel_handlers/video_assignment_channel_handler.ts
@@ -307,7 +307,10 @@ export class VideoAssignmentChannelHandler {
   private assignVideoMeetStreamTrack(mediaEntry: MediaEntry) {
     for (const [meetStreamTrack, internalMeetStreamTrack] of this
       .internalMeetStreamTrackMap) {
-      if (meetStreamTrack.mediaStreamTrack.kind === 'video') {
+      if (
+        meetStreamTrack.mediaStreamTrack.kind === 'video' &&
+        !meetStreamTrack.mediaEntry.get()
+      ) {
         internalMeetStreamTrack.maybeAssignMediaEntryOnFrame(
           mediaEntry,
           'video',

--- a/web/internal/internal_meet_stream_track_impl.ts
+++ b/web/internal/internal_meet_stream_track_impl.ts
@@ -27,7 +27,6 @@ import {InternalMediaEntry, InternalMeetStreamTrack} from './internal_types';
  * Implementation of InternalMeetStreamTrack.
  */
 export class InternalMeetStreamTrackImpl implements InternalMeetStreamTrack {
-  private readonly reader: ReadableStreamDefaultReader;
   videoSsrc?: number;
 
   constructor(
@@ -35,20 +34,7 @@ export class InternalMeetStreamTrackImpl implements InternalMeetStreamTrack {
     readonly mediaEntry: SubscribableDelegate<MediaEntry | undefined>,
     private readonly meetStreamTrack: MeetStreamTrack,
     private readonly internalMediaEntryMap: Map<MediaEntry, InternalMediaEntry>,
-  ) {
-    const mediaStreamTrack = meetStreamTrack.mediaStreamTrack;
-    let mediaStreamTrackProcessor;
-    if (mediaStreamTrack.kind === 'audio') {
-      mediaStreamTrackProcessor = new MediaStreamTrackProcessor({
-        track: mediaStreamTrack as MediaStreamAudioTrack,
-      });
-    } else {
-      mediaStreamTrackProcessor = new MediaStreamTrackProcessor({
-        track: mediaStreamTrack as MediaStreamVideoTrack,
-      });
-    }
-    this.reader = mediaStreamTrackProcessor.readable.getReader();
-  }
+  ) {}
 
   async maybeAssignMediaEntryOnFrame(
     mediaEntry: MediaEntry,
@@ -62,17 +48,25 @@ export class InternalMeetStreamTrackImpl implements InternalMeetStreamTrack {
     ) {
       return;
     }
-    // Loop through the frames until media entry is assigned by either this
+
+    // Loop through until media entry is assigned by either this
     // meet stream track or another meet stream track.
+    // Instead of using MediaStreamTrackProcessor which consumes the track,
+    // we poll the synchronization sources which is non-intrusive.
     while (!this.mediaEntryTrackAssigned(mediaEntry, kind)) {
-      const frame = await this.reader.read();
-      if (frame.done) break;
       if (kind === 'audio') {
         await this.onAudioFrame(mediaEntry);
       } else if (kind === 'video') {
         this.onVideoFrame(mediaEntry);
       }
-      frame.value.close();
+
+      // If already assigned, no need to wait or loop further.
+      if (this.mediaEntryTrackAssigned(mediaEntry, kind)) {
+        break;
+      }
+
+      // Wait for a short duration before checking again.
+      await new Promise((resolve) => setTimeout(resolve, 100));
     }
     return;
   }

--- a/web/internal/meetmediaapiclient_impl.ts
+++ b/web/internal/meetmediaapiclient_impl.ts
@@ -423,6 +423,11 @@ export class MeetMediaApiClientImpl implements MeetMediaApiClient {
         'You must connect to a meeting with video before applying a layout',
       );
     }
+
+    if (requests.length === 0) {
+      throw new Error('At least one media layout request must be provided');
+    }
+
     requests.forEach((request) => {
       if (!request.mediaLayout) {
         throw new Error('The request must include a media layout');
@@ -433,7 +438,16 @@ export class MeetMediaApiClientImpl implements MeetMediaApiClient {
         );
       }
     });
-    return this.videoAssignmentChannelHandler.sendRequests(requests);
+
+    const finalRequests = [...requests];
+    const lastRequest = requests[requests.length - 1];
+    while (
+      finalRequests.length < this.requiredConfiguration.numberOfVideoStreams
+    ) {
+      finalRequests.push(lastRequest);
+    }
+
+    return this.videoAssignmentChannelHandler.sendRequests(finalRequests);
   }
 
   createMediaLayout(canvasDimensions: CanvasDimensions): MediaLayout {

--- a/web/samples/script.ts
+++ b/web/samples/script.ts
@@ -19,9 +19,12 @@ import {MeetConnectionState} from '../types/enums';
 import {MeetStreamTrack} from '../types/mediatypes';
 import {MeetSessionStatus} from '../types/meetmediaapiclient';
 
+let requestedVideoStreamCount = 0;
+
 // Function maps session status to strings. If the session is joined, we go
 // ahead and request a layout.
 async function handleSessionChange(status: MeetSessionStatus) {
+  console.log('handleSessionChange:', status);
   let statusString;
   switch (status.connectionState) {
     case MeetConnectionState.WAITING:
@@ -31,8 +34,13 @@ async function handleSessionChange(status: MeetSessionStatus) {
       statusString = 'JOINED';
       // tslint:disable-next-line:no-any
       const client = (window as any).client;
-      const mediaLayout = client.createMediaLayout({width: 500, height: 500});
-      const response = await client.applyLayout([{mediaLayout}]);
+      const layouts = [];
+      for (let i = 0; i < requestedVideoStreamCount; i++) {
+        layouts.push({
+          mediaLayout: client.createMediaLayout({width: 500, height: 500}),
+        });
+      }
+      const response = await client.applyLayout(layouts);
       console.log(response);
       break;
     case MeetConnectionState.DISCONNECTED:
@@ -86,6 +94,7 @@ function handleStreamChange(meetStreamTracks: MeetStreamTrack[]) {
       const videoIdString = `video-${videoId}`;
       const videoElement = document.getElementById(videoIdString);
       (videoElement! as HTMLVideoElement).srcObject = mediaStream;
+      (videoElement! as HTMLVideoElement).play();
       trackIdToElementId.set(meetStreamTrack.mediaStreamTrack.id, videoId);
     } else if (meetStreamTrack.mediaStreamTrack.kind === 'audio') {
       const elementId = trackIdToElementId.get(
@@ -112,6 +121,7 @@ function handleStreamChange(meetStreamTracks: MeetStreamTrack[]) {
       const audioIdString = `audio-${audioId}`;
       const audioElement = document.getElementById(audioIdString);
       (audioElement! as HTMLAudioElement).srcObject = mediaStream;
+      (audioElement! as HTMLAudioElement).play();
       trackIdToElementId.set(meetStreamTrack.mediaStreamTrack.id, audioId);
     }
   });
@@ -131,6 +141,7 @@ export function createClient(
   enableAudioStreams: boolean,
   accessToken: string,
 ) {
+  requestedVideoStreamCount = numberOfVideoStreams;
   const client = new MeetMediaApiClientImpl({
     meetingSpaceId,
     numberOfVideoStreams,
@@ -141,7 +152,6 @@ export function createClient(
   (window as any).client = client;
   client.sessionStatus.subscribe(handleSessionChange);
   client.meetStreamTracks.subscribe(handleStreamChange);
-  console.log('Media API Client created.');
 }
 
 /**

--- a/web/samples/script.ts
+++ b/web/samples/script.ts
@@ -19,8 +19,6 @@ import {MeetConnectionState} from '../types/enums';
 import {MeetStreamTrack} from '../types/mediatypes';
 import {MeetSessionStatus} from '../types/meetmediaapiclient';
 
-let requestedVideoStreamCount = 0;
-
 // Function maps session status to strings. If the session is joined, we go
 // ahead and request a layout.
 async function handleSessionChange(status: MeetSessionStatus) {
@@ -136,7 +134,6 @@ export function createClient(
   enableAudioStreams: boolean,
   accessToken: string,
 ) {
-  requestedVideoStreamCount = numberOfVideoStreams;
   const client = new MeetMediaApiClientImpl({
     meetingSpaceId,
     numberOfVideoStreams,

--- a/web/samples/script.ts
+++ b/web/samples/script.ts
@@ -34,13 +34,8 @@ async function handleSessionChange(status: MeetSessionStatus) {
       statusString = 'JOINED';
       // tslint:disable-next-line:no-any
       const client = (window as any).client;
-      const layouts = [];
-      for (let i = 0; i < requestedVideoStreamCount; i++) {
-        layouts.push({
-          mediaLayout: client.createMediaLayout({width: 500, height: 500}),
-        });
-      }
-      const response = await client.applyLayout(layouts);
+      const mediaLayout = client.createMediaLayout({width: 500, height: 500});
+      const response = await client.applyLayout([{mediaLayout}]);
       console.log(response);
       break;
     case MeetConnectionState.DISCONNECTED:


### PR DESCRIPTION
This PR addresses a bug where only one video stream would play at a time, even when multiple streams were requested. The fix involves resolving a "frame stealing" issue in the internal library and implementing
  automatic layout repetition to simplify client-side configuration.

  Changes

  Internal Library Logic
   - Resolved "Frame Stealing": Removed the use of MediaStreamTrackProcessor in InternalMeetStreamTrackImpl. The previous implementation was consuming and closing frames to detect SSRCs, which prevented those frames
     from reaching the DOM <video> elements.
   - Non-Intrusive SSRC Polling: Replaced the processor with a non-intrusive polling mechanism that uses RTCRtpReceiver.getSynchronizationSources() and getContributingSources(). This allows the library to identify and
     assign tracks to media entries without interrupting the media flow.
   - Automatic Layout Repetition: Updated MeetMediaApiClientImpl.applyLayout to automatically repeat the last provided MediaLayoutRequest if the number of requests is fewer than the numberOfVideoStreams configured at
     session start. This maintains backward compatibility with simpler client implementations while ensuring all requested streams are active.
   - Assignment Optimization: Refined VideoAssignmentChannelHandler and MediaEntriesChannelHandler to only trigger the assignment search for tracks that do not already have an associated media entry, reducing redundant
     processing.

  Sample Application
   - Stability: Added explicit .play() calls to media elements upon assignment to ensure reliable playback across different browser autoplay policies.

  Verification Results
   - Build: Successfully verified with npx webpack in the samples directory.
   - Functionality: Verified that multiple video streams now play simultaneously even when only a single media layout is explicitly provided by the client.